### PR TITLE
Termo de Ciência e Consentimento - Transferências para Associados e Divulgação de Anuidades

### DIFF
--- a/app/members/templates/members/member_form.html
+++ b/app/members/templates/members/member_form.html
@@ -23,6 +23,19 @@
             <hr>
             <fieldset>
                 {% bootstrap_form member_form layout='horizontal' %}
+                {% if show_consent_form %}
+                <div class="form-group">
+                    <label class="col-md-3 control-label">Termo de Consentimento</label>
+                    <div class="col-md-9">
+                        <p>O <a href="https://docs.google.com/document/d/e/2PACX-1vTpHHJLlnCKBxHfMmZGXtJYnEvnAzAq-FfXEmMJvU8NtWdusRpqR1yUguQYxTDYPg85Q5Vd4kEuQRsd/pub">Termo de Ciência e Consentimento - Transferências para Associados e Divulgação de Anuidades</a> tem a finalidade de regulamentar os requisitos para a realização, por qualquer motivo, de: a) transferências de recursos financeiros pela Associação Python Brasil (APyB) para pessoas físicas que sejam formalmente associadas à entidade; b) pagamento de anuidades por associados.</p>
+                        <div class="checkbox">
+                            <label for="id_termo">
+                                <input type="checkbox" id="id_termo" checked="" required> Li e concordo com o termo.</label>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                {% endif %}
                 <div class='form-actions'>
                     <button type="submit" class="btn btn-primary">
                         {% trans "Submit" %}

--- a/app/members/views.py
+++ b/app/members/views.py
@@ -102,12 +102,14 @@ def member_form(request):
                 request, messages.ERROR,
                 _('An error occurred while trying to save your data. check the form below. '))
 
+    show_consent_form = member.id == None
     return render(
         request,
         "members/member_form.html",
         {
             "member_form": member_form,
-            'user_form': user_form
+            "user_form": user_form,
+            "show_consent_form": show_consent_form,
         }
     )
 


### PR DESCRIPTION
Adiciona checkbox "li e concordo" ao formulário de associação.

Link para o termo: https://docs.google.com/document/d/e/2PACX-1vTpHHJLlnCKBxHfMmZGXtJYnEvnAzAq-FfXEmMJvU8NtWdusRpqR1yUguQYxTDYPg85Q5Vd4kEuQRsd/pub

![Screenshot 2022-07-24 at 17 38 37](https://user-images.githubusercontent.com/431892/180657310-cff53ec7-eb6e-440d-88f5-ab73b730bfab.png)

