### PR TITLE
Atualiza versão do django-municipios

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,9 @@ lxml==4.9.1
 python-decouple==3.0
 boto==2.42.0
 django-storages==1.5.1
-six==1.10.0
+six==1.16.0
 django-localflavor==2.2
 cssselect==0.9.2
-git+https://github.com/znc-sistemas/django-municipios.git@68b6a4f9e7303674fd1989c42095618e4a71bc01
+git+https://github.com/znc-sistemas/django-municipios.git@715a0ed661e6e2b2cf210ad9f1a8470d617ead4e
 sentry-sdk==1.14.0
 django-phonenumber-field[phonenumbers]==6.0.0


### PR DESCRIPTION
Um novo commit no `django-municipios` agora deve permitir a atualização para o Django 3:
https://github.com/znc-sistemas/django-municipios/commit/715a0ed661e6e2b2cf210ad9f1a8470d617ead4e