### PR TITLE
Atualiza mensagem de renovação da associação

### DIFF
--- a/app/payment/management/commands/renewal_alert.py
+++ b/app/payment/management/commands/renewal_alert.py
@@ -86,6 +86,7 @@ class Command(BaseCommand):
             "url": "https://apyb.python.org.br/associados/associe-se/",
             "date": self.today,
             "days": (payment.valid_until.date() - self.today).days,
+            "discussions": "https://github.com/apyb/comunidade/discussions",
         }
 
     def handle(self, *_args, **options):

--- a/app/payment/management/commands/renewal_alert.py
+++ b/app/payment/management/commands/renewal_alert.py
@@ -15,7 +15,7 @@ from django.utils import timezone, translation
 from app.payment.models import Payment
 
 TIME_ZONE = pytz.timezone(settings.TIME_ZONE)
-DAYS_BEFORE_EXPIRATION_TO_ALERT = (60, 30, 15, 7, 1)
+DAYS_BEFORE_EXPIRATION_TO_ALERT = (30, 15, 7, 1)
 
 
 @contextmanager

--- a/app/payment/templates/payment/valid_until_email.txt
+++ b/app/payment/templates/payment/valid_until_email.txt
@@ -9,7 +9,7 @@ Para efetuar a sua renovação é só seguir o link abaixo:
 
 Vale lembrar que apenas os membros em dia com sua anuidade podem participar das assembleias da Associação Python Brasil bem como outros direitos garantidos a todos os membros.
 
-Caso tenha alguma dúvida é só entrar em contato conosco através do e-mail: {{ contact_email }} ou no {{ discussions }}.
+Caso tenha alguma dúvida é só entrar em contato conosco através do e-mail {{ contact_email }} ou pela comunidade no Github {{ discussions }}.
 
 Obrigado,
 Equipe da Associação Python Brasil

--- a/app/payment/templates/payment/valid_until_email.txt
+++ b/app/payment/templates/payment/valid_until_email.txt
@@ -14,4 +14,4 @@ Caso tenha alguma dúvida é só entrar em contato conosco através do e-mail {{
 Obrigado,
 Equipe da Associação Python Brasil
 
-PS. O sistema de controle de associados está em fase de migração. Por causa disso, você pode acabar recebendo esse e-mail outras vezes mesmo já tendo feito a renovação. Pedimos desculpas por qualquer incômodo causado. 
+PS. O sistema de controle de associados está em fase de migração. Por causa disso, você pode acabar recebendo esse e-mail outras vezes mesmo já tendo feito a renovação. Saiba mais em: https://github.com/apyb/comunidade/discussions/139

--- a/app/payment/templates/payment/valid_until_email.txt
+++ b/app/payment/templates/payment/valid_until_email.txt
@@ -1,18 +1,17 @@
 Olá {{ member.user.get_full_name }},
 
-Esse e-mail é um lembrete de que faltam {{ days }} dias para o vencimento da anuidade referente à sua associação.
+Esse e-mail é um lembrete de que faltam {{ days }} dias para o vencimento da anuidade referente à sua associação. Caso você já tenha efetuado o pagamento pedimos que desconsidere esse aviso.
 
 Para efetuar a sua renovação é só seguir o link abaixo:
 
 {{ url }}
 
-Vale lembrar que apenas os membros em dia com sua anuidade podem participar das assembleias da Associação Python Brasil bem como outros direitos garantidos a todos os membros (ex. descontos para inscrições de eventos organizados pela associação).
 
-Caso você já tenha efetuado o pagamento pedimos que desconsidere esse aviso.
+Vale lembrar que apenas os membros em dia com sua anuidade podem participar das assembleias da Associação Python Brasil bem como outros direitos garantidos a todos os membros.
 
-Caso tenha alguma dúvida é só entrar em contato conosco através do e-mail: {{ contact_email }}.
+Caso tenha alguma dúvida é só entrar em contato conosco através do e-mail: {{ contact_email }} ou no {{ discussions }}.
 
 Obrigado,
 Equipe da Associação Python Brasil
 
-PS. O sistema de controle de associados está em fase de implantação. Caso encontre algum problema pedimos a gentileza de nos avisar através do mesmo endereço de e-mail: {{ contact_email }}.
+PS. O sistema de controle de associados está em fase de migração. Por causa disso, você pode acabar recebendo esse e-mail outras vezes mesmo já tendo feito a renovação. Pedimos desculpas por qualquer incômodo causado. 

--- a/app/payment/tests/test_commands.py
+++ b/app/payment/tests/test_commands.py
@@ -48,7 +48,7 @@ class RenewalAlertTest(TestCase):
                 self.assertIn(self.user.get_full_name(), mail.outbox[0].body)
 
     def test_renewal_alert_sends_email_alerts_before_membership_expires(self):
-        test_cases = (60, 30, 15, 7)
+        test_cases = (30, 15, 7)
         for days in test_cases:
             mail.outbox = []
             self.payment.valid_until = self.now + timedelta(days=days)


### PR DESCRIPTION
Baseado nos feedbacks que recebemos por e-mail e pelo discussions, estou alterando a mensagem de renovação com o intuíto de deixar mais claro que caso a pessoa já tenha feito o pagamento, desconsidere a mensagem.

Closes https://github.com/apyb/tarefas/issues/973